### PR TITLE
2장-타입-양창훈

### DIFF
--- a/양창훈/챕터2/그냥타입.md
+++ b/양창훈/챕터2/그냥타입.md
@@ -1,0 +1,299 @@
+# 2.1 타입이란
+
+## 자료형으로서의 타입
+
+변수 ⇒ 값을 저장할 수 있는 공간이자 값을 가리키는 이름.
+
+```ts
+var name = 'zig';
+var year = 2020;
+name & year => 변수 명
+zig & 2020 => 값
+```
+
+데이터 타입은 여러 종류의 데이터를 식별하는 분류 체계로 컴파일러에 값의 형태를 알려준다.
+
+종류는 아래와 같다.
+
+**undefined | null | Boolean | String | Symbol | Numeric(Number와 BigInt) | Object**
+
+## 집합으로서의 타입
+
+타입은 수학의 잡합과 유사하다.
+
+값이 가질 수 있는 유효한 범위의 집합을 타입이라 한다.
+
+```ts
+const num: number = 123;
+const str: string = "abc";
+
+function func(n: number) {
+  // ...
+}
+func(num);
+func(str); // Argument ~~ error
+```
+
+위 코드처럼 값이 가질 수 있는 범위를 제한해 해당 범위안에 속하지 않는 타입을 사용할 경우 에러가 발생한다.
+
+## 정적타입과 동적 타입
+
+타입을 결정하는 시점에 따라 타입을 정적 타입과 동적 타입으로 분류가 될 수 있다.
+
+정적 타입의 경우 모든 변수의 타입이 컴파일타임에 결정된다. 코드 수준에서 개발자가 타입을 명시 해줘야 하는 경우가 정적타입에 해당한다.
+
+동적 타입의 경우 변수 타입이 런타임에서 결정된다.
+
+## 강타입과 약타입
+
+개발자가 의도적으로 타입을 명시하거나 바꾸지 않았는데 컴파일러 과정에 타입이 자동으로 변경되는 것을 암묵적 타입변환이라고 한다.
+
+이런 암묵적 타입 변환 여부에 따라 타입 시스템을 강타입과 약타입으로 분류할 수 있다.
+
+강타입의 경우 서로 다른 타입끼리 연산을 시도하면 에러가 발생하지만
+
+약타입의 경우 서로 다른 타입을 갖는 값끼리 연산할때 내부적으로 판단하여 특정값의 타입을 변환하여
+
+연산을 수행한 후 값을 도출한다.
+
+```ts
+// js
+console.log("2" - 1)
+=> 1
+
+// ts
+console.log("2" - 1) // '2' type error
+```
+
+## 컴파일 방식
+
+컴파일 ⇒ 사람이 이해할 수 있는 코드를 컴퓨터가 이해할 수 있는 기계어로 바꿔주는 과정
+
+ts는 컴파일하면 타입이 모두 제거된 상태의 자바스크립트 소스코드만 남는다.
+
+# 타입스크립트의 타입 시스템
+
+## 타입 애너테이션 방식
+
+변수나 상수 혹은 함수의 인자와 반환 값에 타입을 명시적으로 선헌해서 어떤 타입 값이 저장될 것인지를 컴파일러에 직접 알려주는 문법.
+
+ts는
+
+```ts
+let isDone: boolean = false;
+let decimal: number = 6;
+let x: [string, number]; // tuple
+```
+
+변수 이름 뒤에 : type 구문을 붙여 데이터 타입을 명시해줌
+
+type 선언을 제거해도 코드가 정상적으로 작동하긴함!
+
+## 구조적 타이핑
+
+이름으로 타입을 구분하는 목적인 타입언어의 특정과 달리
+
+타입스크립트는 구조로 타입을 구분한다.
+
+⇒ 구조적 타이핑
+
+## 구조적 서브타이핑
+
+타입스크립트의 타입은 특정 값은 많은 집합에 포함될 수 있따.
+
+특정 값이 string 또는 number타입을 동시에 가질 수 있다.
+
+```ts
+type stringOrNumber = string | number;
+```
+
+위처럼 집합으로 나타낼 수 있는 타입스크림트의 타입 시스템을 지탱하는 개념이 구조적 서브타이핑이다.
+
+객체가 가지고 있는 속성을 바탕으로 타입을 구분하는 것이 구조적 서브타이핑이다.
+
+**이름이 다른 객체라도 가진 속성이 동일하다면 타입스크립트는 서로 호환이 가능한 동일한 타입으로 여긴다.**
+
+```ts
+interface Pet {
+  name: string;
+}
+
+interface Cat {
+  name: string;
+  age: number;
+}
+
+let pet: Pet;
+let cat: Cat = { name: "Zag", age: 2 };
+
+pet = cat; //가능
+```
+
+위에서 Cat과 Pet은 서로 다른 타입이지만
+
+Pet가지고 있는 속성 name을 Cat 또한 가지고 있다.
+
+따라서 구조적 서브타이핑으로
+
+Cat 타입으로 선한 cat을 Pet 타입으로 선언한 pet에 할당할 수 있다.
+
+구조적 서브타이핑은 매개변수에도 적용이된다.
+
+```ts
+interfcae Pet{
+	name: string;
+}
+
+let cat = { name: "Zag", age: 2};
+
+function greet(pet: Pet) {
+	console.log("Hello, " + pet.name);
+}
+greet(cat); // 가능
+```
+
+함수 greet의 타입조건은 Pet으로 되어있다.
+
+다른 타입으로 선언된 cat을 함수 greet에 넣었더니 가능하다.
+
+왜 되냐? ⇒ 구조적 서브타이핑으로 Pet의 속성 타입을 cat의 타입Cat이 가지고 있어서 가능하다.
+
+## 자바스크립트 슈퍼셋으로서의 타입스크립트
+
+자바스크립트의 상위호환 타입스크립트.
+
+자바스크립트가 사용하는 모든 것을 타입스크립트가 쓸 수 있지만.
+
+타입스크립트가 쓰는 모든 것을 자바스크립트가 사용할 순 없다.
+
+## 값 vs 타입
+
+값은 프로그램이 처리하기 위해 메모리에 저장하는 모든 데이터이다.
+
+값 공간과 타입 공간의 이름은 서로 충돌하지 않기 때문에 타입과 변수를 같은 이름으로 정의할 수 있다.
+
+타입스크립트 문법인 type으로 선언한 내용은 자바스크립트 런타임에서 제거되기 때문에 값 공간과 타입 공간은 서로 충돌하지 않는다고 한다.
+
+```ts
+type Devloper = { isWorking: true };
+const Developer = { isTyping: true };
+가능;
+```
+
+함수의 매개변수처럼 여러개의 심볼이 함께 쓰인다면 타입과 값을 명확하게 구분 해야한다.
+
+```ts
+function email(options: {person: Person; subject: string; body; string}){
+	// ... 객체 파라미터에 타입 붙이는 기본 방식
+}
+
+function email({person, subject, body}){
+	//... 구조 분해 할당으로 풀어서 쓰는 방식
+}
+
+근데!
+
+function email({person :
+ Person,
+ string,
+ string}){
+	 //...
+ }
+
+ {person : Person} 이런식의 구조안에서 구조분해를 하는건 안됨
+```
+
+위 오류코드에서 Person,string이 값 공간에 있는 것으로 해석되고
+person과 Person은 각 함수의 매개변수 객체 내부 속성의 키 - 값 {person: Person} 으로
+해석 되어 안됨!
+
+```ts
+function email({
+	person,
+	subject,
+	body
+}: {
+	person: Person;
+	subject: String;
+	body: string;
+}{
+	//...
+}
+)
+```
+
+위 처럼 구조분해를 명확히 해야함.
+
+## 함수 시그니처
+
+함수 타입을 정의할 때 사용하는 문법으로
+
+해당 함수가 받는 매개변수와 반환하는 값의 타입으로 결정됨
+
+함수 자체의 타입을 명시할 때는 화살표 함수 방식으로만 호출 시그니처를 정의한다.
+
+```ts
+type add = (a: number, b: number) => number;
+```
+
+## 타입 단언 as
+
+타입을 강제할 수 있는 as 키워드가 있다.
+타입 단언은 해당 값의 타입을 더 잘 파악할 수 있을때 사용되며 강제 형 변환과 유사한 기능을 제공한다.!
+
+```ts
+const textValue: unknown = "123456789020";
+
+const textFnc = (text: string) => {
+  if (text.length < 10) {
+    console.log("텍스트 10개이상");
+    return;
+  }
+  console.log(text);
+  console.log(text.length);
+  console.log(typeof text);
+};
+
+textFnc(textValue); // 에러 발생
+```
+
+위 코드는 런타임시 에러가 발생한다. 왜?
+함수안 매개변수는 타입 string을 받도록 되어있지만 현재 textValue는 unknown의 타입을 가진다 값이 string일지라도
+
+이때 타입 단언 as를 사용하든가 아니면 unknown의 타입을 string으로 바꾸든가 해야한다
+
+```ts
+const textValue: string = "123456789020";
+
+const textFnc = (text: string) => {
+  if (text.length < 10) {
+    console.log("텍스트 10개이상");
+    return;
+  }
+  console.log(text);
+  console.log(text.length);
+  console.log(typeof text);
+};
+
+textFnc(textValue);
+```
+
+이나
+
+```ts
+const textValue: unknown = "123456789020";
+
+const textFnc = (text: string) => {
+  if (text.length < 10) {
+    console.log("텍스트 10개이상");
+    return;
+  }
+  console.log(text);
+  console.log(text.length);
+  console.log(typeof text);
+};
+
+textFnc(textValue as string);
+```
+
+처럼


### PR DESCRIPTION
<!-- PR Title은 `{n}장-{챕터Title}-이름`으로 작성해주세요.-->

# 🔗 파일 Link
https://github.com/yangchanghun/Woowahan-ts-with-React/blob/main/%EC%96%91%EC%B0%BD%ED%9B%88/%EC%B1%95%ED%84%B02/%EA%B7%B8%EB%83%A5%ED%83%80%EC%9E%85.md
## 📖 새로 알게된 내용
<!-- 새로 알게된 내용 중 인상깊어서 공유하고 싶은 부분을 작성해주세요. -->

**구조적 서브타이핑!**
타입스크립트의 특정 값은 많은 집합에 포함될 수 있다고 한다.
```ts
type stringOrNumber = string | number;
```
위 타입을 가진 변수는 string 이나 number의 타입을 가질 수 있다.


이름이 다른 객체라도 가진 속성이 동일하다면 타입스크립트는 서로 호환이 가능한 동일한 타입으로 여길 수 있다.
```ts
interface Pet {
	name: string;
}

interface Cat {
	name: string;
	age: number;
}

let pet:Pet;
let cat:Cat = {name:"Zag", age: 2};

pet = cat; //가능
```

위의 Cat과 Pet은 서로 다른 타입이지만 Pet의 속성을 Cat이 가지고 있어

구조적 서브타이핑으로 Cat 타입으로 선언한 cat을 Pet 타입으로 선헌한 pet에 할당할 수 있다는 사실.

매개변수에서도 위 구조적 서브 타이핑은 적용된다.

**호출 시그니처**
타입스크립트 거의 모른채로 과제할때 막 따라만 했던 함수 타입? 이제 알게됨
함수 타입을 정의할 때 사용하는 문법으로

해당 함수가 받는 매개변수와 반환하는 값의 타입으로 결정됨

함수 자체의 타입을 명시할 때는 화살표 함수 방식으로만 호출 시그니처를 정의한다.
```ts
type add = (a: number, b: number) => number; 
```

**타입단언 as?**
타입을 강제할 수 있는 as 키워드가 있다. 
타입 단언은 해당 값의 타입을 더 잘 파악할 수 있을때 사용되며 강제 형 변환과 유사한 기능을 제공한다.!

```ts
const textValue: unknown= "123456789020";

const textFnc = (text: string) => {
  if (text.length < 10) {
    console.log("텍스트 10개이상");
    return;
  }
  console.log(text);
  console.log(text.length);
  console.log(typeof text);
};

textFnc(textValue); // 에러 발생
```

위 코드는 런타임시 에러가 발생한다. 
왜? 함수안 매개변수는 타입 string을 받도록 되어있지만 현재 textValue는 unknown의 타입을 가진다 값이 string일지라도

이때 타입 단언 as를 사용하든가 아니면 unknown의 타입을 string으로 바꾸든가 해야한다
```ts
const textValue: string = "123456789020";

const textFnc = (text: string) => {
  if (text.length < 10) {
    console.log("텍스트 10개이상");
    return;
  }
  console.log(text);
  console.log(text.length);
  console.log(typeof text);
};

textFnc(textValue);
```
이나
```ts
const textValue: unknown= "123456789020";

const textFnc = (text: string) => {
  if (text.length < 10) {
    console.log("텍스트 10개이상");
    return;
  }
  console.log(text);
  console.log(text.length);
  console.log(typeof text);
};

textFnc(textValue as string);
```

처럼





## 🦈 공유하고 싶은 부분
<!-- - 이런 부분은 다른 사람들도 알면 좋을 것 같다! -->
## 🤯 어려웠던 내용
<!-- 이해가 어려웠던 내용, 혹은 아직도 어려운 내용도 좋습니다. -->
위 타입단언 as 잘 모르겠다.
애초에 textValue의 타입을 string으로 고정해놓으면 안되나 ?

다른 백api에서 들어온다고 가정했을때 어떤 값이 들어올지 모르니까
unknown으로 타입선언하고

함수호출할때 string으로 강제하는건가 ?

이해안되는거 많았는데 까먹었다.,;


타입 좁히기 내로잉 
```ts
if( typeof value === "string") 
```
**유니온 타입**
or
```ts
string | number ;
"Y" | "N" ;
...

여기서 as는 타입 추론이 안 되거나, 
추론이 너무 복잡해서 TypeScript가 이해 못 할 때, 
혹은 개발자가 명확하게 타입을 알고 있을 때 사용
