### PR TITLE
9장-훅-이의찬

### DIFF
--- a/이의찬/8장 JSX에서 TSX로/8.1 리액트 컴포넌트의 타입.md
+++ b/이의찬/8장 JSX에서 TSX로/8.1 리액트 컴포넌트의 타입.md
@@ -1,0 +1,169 @@
+### 클래스 컴포넌트 타입
+
+클래스 컴포넌트는 `React.Component`나 `React.PureComponent`를 상속받는다. 이 두 타입은 제네릭으로 props와 state 타입을 받는다.
+
+```tsx
+interface WelcomeProps {
+  name: string;
+}
+
+class Welcome extends React.Component<WelcomeProps> {
+  */* ... */*
+}
+```
+
+### 함수 컴포넌트 타입
+
+함수 컴포넌트를 선언하는 방법은 여러 가지다.
+
+```tsx
+*// 함수 선언*
+function Welcome(props: WelcomeProps): JSX.Element {}
+
+*// React.FC 사용*
+const Welcome: React.FC<WelcomeProps> = ({ name }) => {};
+
+*// React.VFC 사용*
+const Welcome: React.VFC<WelcomeProps> = ({ name }) => {};
+
+*// 반환 타입 직접 지정*
+const Welcome = ({ name }: WelcomeProps): JSX.Element => {};
+```
+
+`React.FC`와 `React.VFC`의 차이는 children 타입을 암묵적으로 포함하는지 여부다. `React.FC`는 children을 자동으로 포함하지만, `React.VFC`는 포함하지 않는다. 리액트 v18부터는 `React.VFC`가 삭제되고 `React.FC`에서 children이 제거되었다.
+
+### Children props 타입 지정
+
+가장 보편적인 children 타입은 `ReactNode | undefined`다. 더 구체적으로 타입을 지정하고 싶다면
+
+```tsx
+// 특정 문자열만 허용
+type WelcomeProps = {
+  children: "천생연분" | "더 귀한 분" | "귀한 분" | "고마운 분";
+};
+
+// 모든 문자열 허용
+type WelcomeProps = {
+  children: string;
+};
+
+// ReactElement만 허용
+type WelcomeProps = {
+  children: ReactElement;
+};`
+```
+
+## 렌더링 관련 타입들
+
+### ReactElement vs JSX.Element vs ReactNode
+
+**ReactElement**는 `React.createElement`의 반환 타입으로, 리액트 컴포넌트를 객체 형태로 저장하기 위한 포맷이다
+
+```tsx
+interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = ...> {
+  type: T;
+  props: P;
+  key: Key | null;
+}
+```
+
+**JSX.Element**는 ReactElement를 확장한 타입으로, 글로벌 네임스페이스에 정의되어 있다
+
+```tsx
+declare global {
+  namespace JSX {
+    interface Element extends React.ReactElement<any, any> {}
+  }
+}
+```
+
+**ReactNode**는 ReactElement보다 훨씬 넓은 범위의 타입으로, 리액트의 render 함수가 반환할 수 있는 모든 형태를 담고 있다:
+
+```tsx
+type ReactNode =
+  | ReactChild
+  | ReactFragment
+  | ReactPortal
+  | boolean
+  | null
+  | undefined;
+```
+
+포함 관계: ReactNode > ReactElement > JSX.Element
+
+### 각 타입의 사용 예시
+
+**ReactNode**: children prop처럼 다양한 타입을 허용하고 싶을 때 사용
+
+```tsx
+interface MyComponentProps {
+  children?: React.ReactNode;
+}
+```
+
+**JSX.Element**: render props 패턴으로 리액트 엘리먼트를 전달할 때 사용
+
+```tsx
+interface Props {
+  icon: JSX.Element;
+}
+
+const Item = ({ icon }: Props) => {
+  const iconSize = icon.props.size;
+  return <li>{icon}</li>;
+};
+```
+
+**ReactElement**: 제네릭으로 props 타입을 명시해서 더 정확한 추론이 필요할 때 사용
+
+```tsx
+interface IconProps {
+  size: number;
+}
+
+interface Props {
+  icon: React.ReactElement<IconProps>;
+}
+
+const Item = ({ icon }: Props) => {
+  const iconSize = icon.props.size; *// size가 자동 완성됨*
+  return <li>{icon}</li>;
+};
+```
+
+## HTML 요소 타입 활용하기
+
+### DetailedHTMLProps와 ComponentPropsWithoutRef
+
+HTML 태그의 속성을 활용하는 방법은 크게 두 가지
+
+```tsx
+*// DetailedHTMLProps 사용*
+type NativeButtonProps = React.DetailedHTMLProps
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
+type ButtonProps = {
+  onClick?: NativeButtonProps["onClick"];
+};
+
+*// ComponentPropsWithoutRef 사용*
+type NativeButtonType = React.ComponentPropsWithoutRef<"button">;
+
+type ButtonProps = {
+  onClick?: NativeButtonType["onClick"];
+};
+```
+
+### ref를 다루는 올바른 방법
+
+함수 컴포넌트에서 ref를 전달받으려면 `forwardRef`를 사용해야 한다
+
+```tsx
+const Button = forwardRef<HTMLButtonElement, NativeButtonType>((props, ref) => {
+  return <button ref={ref} {...props}>버튼</button>;
+});
+```
+
+이때 props 타입으로는 `ComponentPropsWithoutRef`를 사용하는 것이 안전하다. `DetailedHTMLProps`처럼 ref를 포함하는 타입을 사용하면, 실제로는 동작하지 않는 ref를 받도록 타입이 지정되어 예기치 않은 에러가 발생할 수 있다.

--- a/이의찬/8장 JSX에서 TSX로/8.2 타입스크립트로 리액트 컴포넌트 만들기.md
+++ b/이의찬/8장 JSX에서 TSX로/8.2 타입스크립트로 리액트 컴포넌트 만들기.md
@@ -1,0 +1,151 @@
+## **JSX로** 구현된 **Select** 컴포넌트
+
+### 기본 타입 정의
+
+```tsx
+type Option = Record<string, string>;
+
+interface SelectProps {
+  options: Option;
+  selectedOption?: string;
+  onChange?: (selected?: string) => void;
+}
+
+const Select = ({ options, selectedOption, onChange }: SelectProps): JSX.Element => {
+  *// ...*
+};
+```
+
+### 리액트 이벤트 핸들러 타입
+
+리액트는 브라우저 이벤트를 합성한 합성 이벤트(SyntheticEvent)를 제공한다
+
+```tsx
+const Select = ({ onChange, options, selectedOption }: SelectProps) => {
+  const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    const selected = Object.entries(options).find(
+      ([_, value]) => value === e.target.value
+    )?.[0];
+    onChange?.(selected);
+  };
+
+  return <select onChange={handleChange}>{*/* ... */*}</select>;
+};
+```
+
+### useState에 타입 추가
+
+제네릭 타입을 명시하지 않으면 초깃값의 타입을 기반으로 추론한다
+
+```tsx
+const fruits = {
+  apple: "사과",
+  banana: "바나나",
+  blueberry: "블루베리",
+};
+
+type Fruit = keyof typeof fruits;
+
+const FruitSelect = () => {
+  const [fruit, changeFruit] = useState<Fruit | undefined>();
+  
+  return <Select onChange={changeFruit} options={fruits} selectedOption={fruit} />;
+};
+```
+
+`keyof typeof` 패턴을 사용하면 객체의 키값을 유니온 타입으로 추출할 수 있다.
+
+### 제네릭 컴포넌트 만들기
+
+객체의 키값만 전달받도록 제한하려면 제네릭을 사용한다
+
+```tsx
+interface SelectProps<OptionType extends Record<string, string>> {
+  options: OptionType;
+  selectedOption?: keyof OptionType;
+  onChange?: (selected?: keyof OptionType) => void;
+}
+
+const Select = <OptionType extends Record<string, string>>({
+  options,
+  selectedOption,
+  onChange,
+}: SelectProps<OptionType>) => {
+  *// ...*
+};
+```
+
+이렇게 하면 `selectedOption`에 잘못된 값을 전달할 때 타입 에러가 발생한다.
+
+### HTML 속성 추가하기
+
+`Pick`이나 인덱스 접근을 활용해 필요한 HTML 속성을 추가할 수 있다
+
+```tsx
+type ReactSelectProps = React.ComponentPropsWithoutRef<"select">;
+
+interface SelectProps<OptionType extends Record<string, string>>
+  extends Pick<ReactSelectProps, "id" | "className"> {
+  options: OptionType;
+  selectedOption?: keyof OptionType;
+  onChange?: (selected?: keyof OptionType) => void;
+}
+```
+
+### styled-components로 스타일 적용
+
+먼저 theme 객체와 타입을 정의한다:
+
+```tsx
+const theme = {
+  fontSize: {
+    default: "16px",
+    small: "14px",
+    large: "18px",
+  },
+  color: {
+    white: "#FFFFFF",
+    black: "#000000",
+  },
+};
+
+type Theme = typeof theme;
+type FontSize = keyof Theme['fontSize'];
+type Color = keyof Theme['color'];
+```
+
+스타일 props를 정의하고 `Partial`로 옵셔널하게 만든다:
+
+```tsx
+interface SelectStyleProps {
+  color: Color;
+  fontSize: FontSize;
+}
+
+const StyledSelect = styled.select<SelectStyleProps>`
+  color: ${({ color }) => theme.color[color]};
+  font-size: ${({ fontSize }) => theme.fontSize[fontSize]};
+`;
+
+interface SelectProps<OptionType extends Record<string, string>>
+  extends Partial<SelectStyleProps> {
+  *// ...*
+}
+```
+
+## 공변성과 반공변성
+
+객체의 메서드 타입을 정의하는 방법은 두 가지가 있고, 미묘한 차이가 있다:
+
+```tsx
+interface Props<T extends string> {
+  onChangeA?: (selected: T) => void;  *// 반공변성*
+  onChangeB?(selected: T): void;       *// 이변성*
+}
+```
+
+**공변성**: 타입 A가 B의 서브타입일 때, `T<A>`가 `T<B>`의 서브타입이 되는 성질
+
+**반공변성**: 타입 A가 B의 서브타입일 때, `T<B>`가 `T<A>`의 서브타입이 되는 성질
+
+함수 타입을 화살표 표기법으로 작성하면 반공변성을 띠게 되고, 일반 메서드 표기법으로 작성하면 이변성(공변성 + 반공변성)을 띠게 된다. 안전한 타입 가드를 위해서는 반공변적인 함수 타입을 설정하는 것이 권장된다.

--- a/이의찬/9장 훅/9.1 리액트 훅.md
+++ b/이의찬/9장 훅/9.1 리액트 훅.md
@@ -1,0 +1,495 @@
+# 9장 - 훅(Hook)
+
+## 리액트 훅이 등장한 배경
+
+리액트 훅은 함수 컴포넌트에서도 클래스 컴포넌트처럼 생명주기에 따라 로직을 실행할 수 있게 해주는 기능이다. 훅이 도입되기 전에는 클래스 기반 컴포넌트를 주로 사용했는데, 몇 가지 불편한 점이 있었다.
+
+**클래스 컴포넌트의 문제점**
+
+1. **컴포넌트 간 상태 로직 재사용이 어려움** - 스토어에 연결하여 값을 동기화하거나, 비슷한 형태의 상태 로직을 각 컴포넌트에서 직접 작성해야 했다. render props나 고차 컴포넌트 같은 방식으로 로직을 재사용할 수는 있었지만, 근본적인 해결 방법은 아니었다.
+2. **생명주기 메서드에 관련 없는 로직들이 뒤섞임** - `componentDidMount`, `componentDidUpdate` 같은 생명주기 메서드에서만 상태 업데이트에 대한 사이드 이펙트를 처리할 수 있었다. 이로 인해 모든 상태 관련 코드들이 생명주기 메서드에 몰려있게 되고, 컴포넌트의 복잡성이 증가했다.
+
+리액트 16.8부터 훅이라는 개념이 도입되면서 이런 문제들을 해결하고자 했다.
+
+---
+
+## 1. useState
+
+함수 컴포넌트에서 상태를 관리하기 위해 `useState` 훅을 활용할 수 있다.
+
+### 타입 정의
+
+```tsx
+function useState<S>(
+  initialState: S | (() => S)
+): [S, Dispatch<SetStateAction<S>>];
+
+type Dispatch<A> = (value: A) => void;
+type SetStateAction<S> = S | ((prevState: S) => S);
+
+```
+
+`useState`가 반환하는 튜플의 첫 번째 요소는 제네릭으로 지정한 S 타입이고, 두 번째 요소는 상태를 업데이트할 수 있는 Dispatch 타입의 함수다.
+
+Dispatch 함수의 제네릭으로 지정한 `SetStateAction`에는 useState로 관리할 상태 타입인 S 또는 이전 상태 값을 받아 새로운 상태를 반환하는 함수 `(prevState: S) => S`가 들어갈 수 있다.
+
+### 타입스크립트 없이 사용할 때의 문제
+
+```tsx
+const MemberList = () => {
+  const [memberList, setMemberList] = useState([
+    { name: "KingBaedal", age: 10 },
+    { name: "MayBaedal", age: 9 },
+  ]);
+
+  const sumAge = memberList.reduce((sum, member) => sum + member.age, 0);
+
+  const addMember = () => {
+    setMemberList([
+      ...memberList,
+      {
+        name: "DokgoBaedal",
+        agee: 11, // ❌ 잘못된 속성명
+      },
+    ]);
+  };
+};
+
+```
+
+기존 memberList 배열 요소에는 없는 `agee`라는 잘못된 속성이 포함된 객체가 추가되었다. 이로 인해 sumAge 변수가 NaN이 되는 예상치 못한 사이드 이펙트가 발생할 수 있다.
+
+### 타입스크립트로 안전하게 사용하기
+
+```tsx
+interface Member {
+  name: string;
+  age: number;
+}
+
+const MemberList = () => {
+  const [memberList, setMemberList] = useState<Member[]>([]);
+
+  // member의 타입이 Member 타입으로 보장된다
+  const sumAge = memberList.reduce((sum, member) => sum + member.age, 0);
+
+  const addMember = () => {
+    // ❌ Error: Type '{ name: string; agee: number; }'
+    // is not assignable to type 'Member'
+    setMemberList([
+      ...memberList,
+      {
+        name: "DokgoBaedal",
+        agee: 11,
+      },
+    ]);
+  };
+};
+
+```
+
+setMemberList의 호출 부분에서 추가하려는 객체의 타입을 확인하여 컴파일타임에 타입 에러를 발견할 수 있다.
+
+---
+
+## 2. 의존성 배열을 사용하는 훅
+
+### useEffect와 useLayoutEffect
+
+렌더링 이후 리액트 함수 컴포넌트에 어떤 일을 수행해야 하는지 알려주기 위해 `useEffect` 훅을 활용할 수 있다.
+
+```tsx
+function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+type DependencyList = ReadonlyArray<any>;
+type EffectCallback = () => void | Destructor;
+
+```
+
+useEffect의 첫 번째 인자인 effect의 타입인 `EffectCallback`은 Destructor를 반환하거나 아무것도 반환하지 않는 함수다. 
+
+useEffect는 **Promise 타입은 반환하지 않으므로 useEffect의 콜백 함수에는 비동기 함수가 들어갈 수 없다.** useEffect에서 비동기 함수를 호출할 수 있다면 경쟁 상태(Race Condition)를 불러일으킬 수 있기 때문이다.
+
+```tsx
+type EffectCallback = () => void | Destructor;
+
+// 즉, 이렇게 반환해야 함
+useEffect(() => {
+  // ...
+  return () => {
+    // 클린업 함수 (또는 아무것도 반환 안 함)
+  };
+}, []);
+```
+
+> 경쟁 상태(Race Condition)
+> 
+> 
+> 멀티스레딩 환경에서 동시에 여러 프로세스나 스레드가 공유된 자원에 접근하려고 할 때 발생할 수 있는 문제다. 이런 상황에서 실행 순서나 타이밍을 예측할 수 없게 되어 프로그램 동작이 원하지 않는 방향으로 흐를 수 있다.
+> 
+
+```tsx
+function UserProfile({ userId }) {
+  const [user, setUser] = useState(null);
+  
+  // ❌ 만약 이게 가능하다면...
+  useEffect(async () => {
+    const userData = await fetchUser(userId); // 3초 걸림
+    setUser(userData);
+  }, [userId]);
+  
+  return <div>{user?.name}</div>;
+}
+```
+
+**시나리오:**
+1. 사용자가 userId=1인 프로필 열기 → API 요청 시작 (3초 걸림)
+2. 0.5초 후, userId=2로 변경 → 또 다른 API 요청 시작 (2초 걸림)
+3. 0.5초 후, userId=3으로 변경 → 또 다른 API 요청 시작 (1초 걸림)
+
+**결과:**
+- userId=3 요청이 먼저 도착 (2초 후) → 화면에 user 3 표시
+- userId=1 요청이 나중에 도착 (3초 후) → **화면에 user 1 표시됨!**
+```
+시간 ─────────────────────────────────────>
+0s    userId=1 요청 시작 ─────────────────> (3초 후 도착)
+0.5s  userId=2 요청 시작 ──────────────> (2.5초 후 도착)
+1s    userId=3 요청 시작 ───────────> (2초 후 도착, 먼저!)
+
+결과: 현재 userId는 3인데, 화면에는 user 1 데이터가 보임!
+```
+
+- 해결 방안
+    
+    ```tsx
+    useEffect(() => {
+      let cancelled = false; // 취소 플래그
+      
+      const fetchData = async () => {
+        const data = await fetchUser(userId);
+        
+        // 컴포넌트가 언마운트되거나 userId가 바뀌면
+        // 이미 취소됐으니 setState 안 함
+        if (!cancelled) {
+          setUser(data);
+        }
+      };
+      
+      fetchData();
+      
+      // 클린업 함수: 다음 effect 실행 전에 호출됨
+      return () => {
+        cancelled = true; // 이전 요청은 무시하도록 표시
+      };
+    }, [userId]);
+    ```
+    
+    **동작 과정:**
+    ```
+    1. userId=1, cancelled=false → API 요청 시작
+    2. userId=2로 변경
+       → 클린업 실행: cancelled=true (userId=1 요청 무시)
+       → 새 effect: cancelled=false, API 요청 시작
+    3. userId=1 응답 도착
+       → cancelled=true이므로 setUser 안 함! ✅
+    4. userId=2 응답 도착
+       → cancelled=false이므로 setUser 실행 ✅
+    ```
+    
+    ```tsx
+    useEffect(() => {
+      const controller = new AbortController();
+      
+      const fetchData = async () => {
+        try {
+          const response = await fetch(`/api/users/${userId}`, {
+            signal: controller.signal // 취소 신호 전달
+          });
+          const data = await response.json();
+          setUser(data);
+        } catch (error) {
+          if (error.name === 'AbortError') {
+            console.log('요청이 취소됨');
+          }
+        }
+      };
+      
+      fetchData();
+      
+      return () => {
+        controller.abort(); // 실제로 네트워크 요청을 취소!
+      };
+    }, [userId]);
+    ```
+    
+
+### deps 배열 사용 시 주의사항
+
+두 번째 인자인 deps는 옵셔널하게 제공되며 effect가 수행되기 위한 조건을 나열한다. **deps의 원소로 숫자나 문자열 같은 기본 자료형이 아닌 객체나 배열을 넣을 때는 주의해야 한다.**
+
+```tsx
+type SomeObject = {
+  name: string;
+  id: string;
+};
+
+interface LabelProps {
+  value: SomeObject;
+}
+
+const Label: React.FC<LabelProps> = ({ value }) => {
+  useEffect(() => {
+    // value.name과 value.id를 사용해서 작업한다
+  }, [value]);
+};
+
+```
+
+**useEffect는 deps가 변경되었는지를 얕은 비교로만 판단하기 때문에**, 실제 객체 값이 바뀌지 않았더라도 객체의 참조 값이 변경되면 콜백 함수가 실행된다. 부모에서 받은 인자를 직접 deps로 작성한 경우, 원치 않는 렌더링이 반복될 수 있다.
+
+> 얕은 비교(shallow compare)
+> 
+> 
+> 객체나 배열과 같은 복합 데이터 타입의 값을 비교할 때 내부의 각 요소나 속성을 재귀적으로 비교하지 않고, 해당 값들의 참조나 기본 타입 값만을 간단하게 비교하는 것을 말한다.
+> 
+
+**해결 방법**
+
+```tsx
+const { id, name } = value;
+
+useEffect(() => {
+  // value.name과 value.id 대신 name, id를 직접 사용한다
+}, [id, name]);
+
+```
+
+실제로 사용하는 값을 useEffect의 deps에서 사용해야 한다. 이런 특징은 useMemo나 useCallback과 같은 다른 훅에서도 동일하게 적용된다.
+
+### Destructor (클린업 함수)
+
+useEffect는 Destructor를 반환하는데 이것은 컴포넌트가 마운트 해제될 때 실행하는 함수다. 하지만 이 말은 어느 정도만 맞다.
+
+- deps가 빈 배열이라면 useEffect의 콜백 함수는 컴포넌트가 처음 렌더링될 때만 실행되며, 이때의 Destructor(클린업 함수)는 컴포넌트가 마운트 해제될 때 실행된다.
+- deps 배열이 존재한다면, 배열의 값이 변경될 때마다 Destructor가 실행된다.
+
+> 클린업(Cleanup) 함수
+> 
+> 
+> useEffect나 useLayoutEffect와 같은 리액트 훅에서 사용되며, 컴포넌트가 해제되기 전에 정리(clean up) 작업을 수행하기 위한 함수를 말한다.
+> 
+
+### useLayoutEffect
+
+useEffect와 비슷한 역할을 하는 훅으로 `useLayoutEffect`가 있다. 타입 정의는 useEffect와 동일하며 하는 역할의 차이만 있다.
+
+```tsx
+function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
+```
+
+**useEffect는 레이아웃 배치와 화면 렌더링이 모두 완료된 후에 실행된다.**
+
+```tsx
+const [name, setName] = useState("");
+
+useEffect(() => {
+  // 매우 긴 시간이 흐른 뒤 아래의 setName()을 실행한다고 생각하자
+  setName("배달이");
+}, []);
+
+return <div>{`안녕하세요, ${name}님!`}</div>;
+
+```
+
+이 코드를 실행하면 처음에는 "안녕하세요, 님!"으로 name이 빈칸으로 렌더링된 후, 다시 "안녕하세요, 배달이님!"으로 변경되어 렌더링될 것이다. 만약 name을 지정하는 setName이 오랜 시간이 걸린 후에 실행된다면 사용자는 빈 이름을 오랫동안 보고 있어야 할 것이다.
+
+**useLayoutEffect를 사용하면 화면에 해당 컴포넌트가 그려지기 전에 콜백 함수를 실행하기 때문에 첫 번째 렌더링 때 빈 이름이 뜨는 경우를 방지할 수 있다.**
+
+---
+
+## 3. useMemo와 useCallback
+
+useMemo와 useCallback 모두 이전에 생성된 값 또는 함수를 기억하며, 동일한 값과 함수를 반복해서 생성하지 않도록 해주는 훅이다. 어떤 값을 계산하는 데 오랜 시간이 걸릴 때나 렌더링이 자주 발생하는 form에서 useMemo나 useCallback을 유용하게 사용할 수 있다.
+
+```tsx
+type DependencyList = ReadonlyArray<any>;
+
+function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+
+function useCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  deps: DependencyList
+): T;
+
+```
+
+두 훅 모두 제네릭을 지원하기 위해 T 타입을 선언해주며 useCallback은 함수를 저장하기 위해 제네릭의 기본 타입을 지정하고 있다.
+
+둘 다 useEffect와 비슷한 주의사항이 존재한다. 두 훅은 deps 배열을 갖고 있으며 해당 의존성이 변경되면 값을 다시 계산하게 된다. 얕은 비교를 수행하기 때문에 deps 배열이 변경되지 않았는데도 다시 계산되지 않도록 주의해야 한다.
+
+**불필요한 곳에 사용하지 않도록 하는 것도 중요하다.** 모든 값과 함수를 useMemo와 useCallback을 사용해서 과도하게 메모이제이션하면 컴포넌트의 성능 향상이 보장되지 않을 수 있다.
+
+> 메모이제이션(Memoization)
+> 
+> 
+> 이전에 계산한 값을 저장함으로써 같은 입력에 대한 연산을 다시 수행하지 않도록 최적화하는 기술이다.
+> 
+
+---
+
+## 4. useRef
+
+리액트 애플리케이션에서 `<input />` 요소에 포커스를 설정하거나 특정 컴포넌트의 위치로 스크롤을 하는 등 **DOM을 직접 선택**해야 하는 경우가 발생할 수 있다. 이때 리액트의 useRef를 사용한다.
+
+```tsx
+const MyComponent = () => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  const onClick = () => {
+    ref.current?.focus();
+  };
+
+  return (
+    <>
+      <button onClick={onClick}>ref에 포커스!</button>
+      <input ref={ref} />
+    </>
+  );
+};
+
+```
+
+### useRef의 세 가지 타입 정의
+
+useRef는 세 종류의 타입 정의를 가지고 있다. useRef에 넣어주는 인자 타입에 따라 반환되는 타입이 달라진다.
+
+```tsx
+function useRef<T>(initialValue: T): MutableRefObject<T>;
+function useRef<T>(initialValue: T | null): RefObject<T>;
+function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+
+interface MutableRefObject<T> {
+  current: T;
+}
+
+interface RefObject<T> {
+  readonly current: T | null;
+}
+
+```
+
+useRef는 `MutableRefObject` 또는 `RefObject`를 반환한다.
+
+- MutableRefObject의 current는 값을 변경할 수 있다. 만약 null을 허용하기 위해 useRef의 제네릭에 `HTMLInputElement | null` 타입을 넣어주었다면, MutableRefObject의 current는 변경할 수 있는 값이 된다.
+    
+    → null을 
+    
+- RefObject의 current는 readonly로 값을 변경할 수 없다. 예시에서는 useRef의 제네릭으로 `HTMLInputElement`를 넣고, 인자에 null을 넣으면 useRef의 두 번째 타입 정의를 따르게 된다.
+
+### 자식 컴포넌트에 ref 전달하기
+
+`<button />`이나 `<input />`과 같은 기본 HTML 요소가 아닌, 리액트 컴포넌트에 ref를 전달할 수도 있다. 그러나 이때 ref를 일반적인 props로 넘겨주는 방식으로 전달하면 브라우저에서 경고 메시지를 띄운다.
+
+→ 이제는 그냥 ref를 props로 직접 전달 가능([Link](https://ko.react.dev/reference/react/forwardRef))
+
+- 원래 class형 컴포넌트가 주류였던 시절, 부모 컴포넌트가 자식 컴포넌트의 메서드를 호출할 수 있었음
+    
+    ```tsx
+    class Child extends React.Component {
+      doSomething() {
+        console.log('called!');
+      }
+      
+      render() {
+        return <div>Child</div>;
+      }
+    }
+    
+    class Parent extends React.Component {
+      childRef = React.createRef();
+      
+      componentDidMount() {
+        // ref.current = Child 인스턴스
+        this.childRef.current.doSomething();
+      }
+      
+      render() {
+        return <Child ref={this.childRef} />;
+      }
+    }
+    ```
+    
+- 함수 컴포넌트
+    
+    ```tsx
+    // ❌ 이건 에러!
+    function FunctionComponent() {
+      return <div>Function</div>;
+    }
+    
+    class Parent extends React.Component {
+      funcRef = React.createRef();
+      
+      componentDidMount() {
+        // ref.current = ??? 
+        // 함수 컴포넌트는 인스턴스가 없음!
+        console.log(this.funcRef.current); // null
+      }
+      
+      render() {
+        return <FunctionComponent ref={this.funcRef} />; // ⚠️ 경고
+      }
+    }
+    ```
+    
+
+---
+
+## useRef의 여러 가지 특성
+
+useRef는 자식 컴포넌트를 저장하는 변수로 활용할 수 있을 뿐만 아니라 다른 방식으로도 유용하게 사용할 수 있다.
+
+### 특성 1: 리렌더링을 발생시키지 않음
+
+- **useRef로 관리되는 변수는 값이 바뀌어도 컴포넌트의 리렌더링이 발생하지 않는다.** 이런 특성을 활용하면 상태가 변경되더라도 불필요한 리렌더링을 피할 수 있다.
+
+### 특성 2: 즉시 값 조회 가능
+
+- 리액트 컴포넌트의 상태는 상태 변경 함수를 호출하고 렌더링된 이후에 업데이트된 상태를 조회할 수 있다. 반면 **useRef로 관리되는 변수는 값을 설정한 후 즉시 조회할 수 있다.**
+
+```tsx
+type BannerProps = {
+  autoplay: boolean;
+};
+
+const Banner: React.FC<BannerProps> = ({ autoplay }) => {
+  const isAutoPlayPause = useRef(false);
+
+  if (autoplay) {
+    // keepAutoPlay 같이 isAutoPlay가 변하자마자 사용해야 할 때 쓸 수 있다
+    const keepAutoPlay = !touchPoints[0] && !isAutoPlayPause.current;
+    // ...
+  }
+
+  return (
+    <>
+      {autoplay && (
+        <button
+          aria-label="자동 재생 일시 정지"
+          // isAutoPlayPause는 사실 렌더링에는 영향을 미치지 않고 로직에만 영향을 주므로
+          // 상태로 사용해서 불필요한 렌더링을 유발할 필요가 없다
+          onClick={() => { isAutoPlayPause.current = true }}
+        />
+      )}
+    </>
+  );
+};
+
+```
+
+[(번역) 리액트는 이미 변했습니다. 훅 역시 변해야 합니다.](https://ricki-lee.medium.com/%EB%B2%88%EC%97%AD-%EB%A6%AC%EC%95%A1%ED%8A%B8%EB%8A%94-%EC%9D%B4%EB%AF%B8-%EB%B3%80%ED%96%88%EC%8A%B5%EB%8B%88%EB%8B%A4-%ED%9B%85-%EC%97%AD%EC%8B%9C-%EB%B3%80%ED%95%B4%EC%95%BC-%ED%95%A9%EB%8B%88%EB%8B%A4-1ff0faf23920)
+
+[forwardRef – React](https://ko.react.dev/reference/react/forwardRef)
+
+공유하고 싶었던 내용: hook이 바뀌었음. useEffect를 잘 쓰는지 확인해보고, useEffectEvent와 useSyncExternal을 쓰는 것도 고려하자.
+
+재밌는 알게 된 내용: ForwardRef는 왜 필요했고, 왜 사라졌을까.

--- a/이의찬/9장 훅/9.2 커스텀 훅.md
+++ b/이의찬/9장 훅/9.2 커스텀 훅.md
@@ -1,0 +1,88 @@
+### 나만의 훅 만들기
+
+리액트에서 기본적으로 제공하는 useState, useEffect, useRef 등의 훅에 더해, **사용자 정의 훅을 생성하여 컴포넌트 로직을 함수로 뽑아내 재사용**할 수 있다.
+
+커스텀 훅(Custom Hook)은 리액트 컴포넌트 내에서만 사용할 수 있는데 이름은 반드시 use로 시작해야 한다.
+
+가장 일반적인 커스텀 훅인 `useInput`을 예시로 작성해보자. useInput은 인자로 받은 초깃값을 useState로 관리하며, 해당 값을 수정할 수 있는 onChange 함수를 input의 값과 함께 반환하는 훅이다.
+
+```tsx
+import { useState } from "react";
+
+const useInput = (initialValue) => {
+  const [value, setValue] = useState(initialValue);
+
+  const onChange = (e) => {
+    setValue(e.target.value);
+  };
+
+  return { value, onChange };
+};
+
+```
+
+이처럼 useInput을 만든 후 컴포넌트 내에서 사용한다.
+
+```tsx
+const MyComponent = () => {
+  const { value, onChange } = useInput("");
+
+  return (
+    <div>
+      <h1>{value}</h1>
+      <input onChange={onChange} value={value} />
+    </div>
+  );
+};
+
+```
+
+### 타입스크립트로 커스텀 훅 강화하기
+
+앞선 useInput 예시를 타입스크립트로 작성해보자. 기존 코드를 .ts 파일에 작성하면 타입스크립트 컴파일러는 에러를 표시한다.
+
+```tsx
+import { useState, useCallback } from "react";
+
+// ❌ Parameter 'initialValue' implicitly has an 'any' type.
+const useInput = (initialValue) => {
+  const [value, setValue] = useState(initialValue);
+
+  // ❌ Parameter 'e' implicitly has an 'any' type.
+  const onChange = useCallback((e) => {
+    setValue(e.target.value);
+  }, []);
+
+  return { value, onChange };
+};
+
+```
+
+useInput 함수의 인자로 넣어준 initialValue와, onChange 함수의 인자로 넣어준 e의 타입이 지정되지 않았기 때문에 발생하는 에러로 **두 군데 모두 타입을 명시적으로 정의해주면 해결된다.**
+
+```tsx
+import { useState, useCallback, ChangeEvent } from "react";
+
+// ✅ initialValue에 string 타입을 정의
+const useInput = (initialValue: string) => {
+  const [value, setValue] = useState(initialValue);
+
+  // ✅ 이벤트 객체인 e에 ChangeEvent<HTMLInputElement> 타입을 정의
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  return { value, onChange };
+};
+
+export default useInput;
+
+```
+
+이때 initialValue와 같은 값은 개발자가 임의로 string 등의 타입으로 지정해줄 수 있지만, `<input />` 요소의 onChange 이벤트로 발생하는 이벤트 객체 e의 타입은 유추하기 힘들다. IDE를 활용하면 타입스크립트 컴파일러(tsc)가 현재 사용하고 있는 이벤트 객체의 타입을 유추해서 알려주므로 유용하다.
+
+```tsx
+// IDE에서 마우스를 올리면 다음과 같이 타입을 보여준다
+// (parameter) e: React.ChangeEvent<HTMLInputElement>
+<input onChange={(e) => { console.log(e) }} />
+```


### PR DESCRIPTION
<!-- PR Title은 `{n}장-{챕터Title}-이름`으로 작성해주세요.-->

## 📖 새로 알게된 내용
<!-- 새로 알게된 내용 중 인상깊어서 공유하고 싶은 부분을 작성해주세요. -->
## 🤯 어려웠던 내용
경쟁상태에 대한 내용이 잘 이해가 안가서 예시코드와 해결방안 작성해봤습니다
```tsx
function UserProfile({ userId }) {
  const [user, setUser] = useState(null);
  
  // ❌ 만약 이게 가능하다면...
  useEffect(async () => {
    const userData = await fetchUser(userId); // 3초 걸림
    setUser(userData);
  }, [userId]);
  
  return <div>{user?.name}</div>;
}
```

**시나리오:**
1. 사용자가 userId=1인 프로필 열기 → API 요청 시작 (3초 걸림)
2. 0.5초 후, userId=2로 변경 → 또 다른 API 요청 시작 (2초 걸림)
3. 0.5초 후, userId=3으로 변경 → 또 다른 API 요청 시작 (1초 걸림)

**결과:**
- userId=3 요청이 먼저 도착 (2초 후) → 화면에 user 3 표시
- userId=1 요청이 나중에 도착 (3초 후) → **화면에 user 1 표시됨!**
```
시간 ─────────────────────────────────────>
0s    userId=1 요청 시작 ─────────────────> (3초 후 도착)
0.5s  userId=2 요청 시작 ──────────────> (2.5초 후 도착)
1s    userId=3 요청 시작 ───────────> (2초 후 도착, 먼저!)

결과: 현재 userId는 3인데, 화면에는 user 1 데이터가 보임!
```

- 해결 방안
  - 1. 클린업 함수 사용해서 구분하기
    
    ```tsx
    useEffect(() => {
      let cancelled = false; // 취소 플래그
      
      const fetchData = async () => {
        const data = await fetchUser(userId);
        
        // 컴포넌트가 언마운트되거나 userId가 바뀌면
        // 이미 취소됐으니 setState 안 함
        if (!cancelled) {
          setUser(data);
        }
      };
      
      fetchData();
      
      // 클린업 함수: 다음 effect 실행 전에 호출됨
      return () => {
        cancelled = true; // 이전 요청은 무시하도록 표시
      };
    }, [userId]);
    ```
    
    **동작 과정:**
    ```
    1. userId=1, cancelled=false → API 요청 시작
    2. userId=2로 변경
       → 클린업 실행: cancelled=true (userId=1 요청 무시)
       → 새 effect: cancelled=false, API 요청 시작
    3. userId=1 응답 도착
       → cancelled=true이므로 setUser 안 함! ✅
    4. userId=2 응답 도착
       → cancelled=false이므로 setUser 실행 ✅
    ```
    - 2. AbortController 사용해서 실제로 network 요청 취소
    ```tsx
    useEffect(() => {
      const controller = new AbortController();
      
      const fetchData = async () => {
        try {
          const response = await fetch(`/api/users/${userId}`, {
            signal: controller.signal // 취소 신호 전달
          });
          const data = await response.json();
          setUser(data);
        } catch (error) {
          if (error.name === 'AbortError') {
            console.log('요청이 취소됨');
          }
        }
      };
      
      fetchData();
      
      return () => {
        controller.abort(); // 실제로 네트워크 요청을 취소!
      };
    }, [userId]);
    ```
## 🦈 공유하고 싶은 주제
1. hook이 바뀌었음. useEffect를 잘 쓰는지 확인해보고, useEffectEvent와 useSyncExternal을 쓰는 것도 고려하자.
2. ForwardRef는 클래스형 컴포넌트에서 Child 인스턴스에 접근할 때 ref를 사용하는 것 때문에 forwardRef로 구분해서 처리했었다. 하지만 이제 함수형 컴포넌트가 완벽하게 자리잡았기에 forwardRef를 제거하고 ref를 그대로 props로 내려줄 수 있도록 변경했다.